### PR TITLE
fix(ReplyError):max client reached error

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,7 @@ class thinkRedis {
    * @return {Object}        [description]
    */
   [_getConnection](config) {
-    delete config.cookie;
-    delete config.key; // fix think-model cache
+    config = helper.omit(config, ['cookie', 'key', 'timeout']);
     const md5 = helper.md5(JSON.stringify(config));
     if (!cacheConn[md5] || !cacheConn[md5].connector.connecting) {
       cacheConn[md5] = new IOredis(config);


### PR DESCRIPTION
不同的redisConfig会使md5计算的值不同，致使某些情况下redis连接数一直上升致超过redis的最大连接数
``` js
   this.cache('somekey', someValue, {
      timeout: Math.floor(Math.random() * 10000),
   }) 
```
![image](https://user-images.githubusercontent.com/31948326/108834524-3facbb00-7609-11eb-957d-2c34e4b5b1a6.png)

只取ioredis的默认配置或者会让md5的判断更准一些?

![image](https://user-images.githubusercontent.com/31948326/108837119-c31bdb80-760c-11eb-8ca0-9defdbfe18ff.png)



